### PR TITLE
Log a helpful error message for EADDRINUSE errors

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+end_of_line = lf
+indent_style = space
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/index.js
+++ b/index.js
@@ -45,6 +45,13 @@ function createServerCluster(server, logger, options) {
       })
     })
 
+    serverDomain.on('error', function (err) {
+      if (err.code === 'EADDRINUSE') {
+        logger.error('Error EADDRINUSE. Port %d already in use.', options.port)
+      }
+      throw err
+    })
+
   }
   , { logger: logger
     , size: options.numProcesses

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "checkStyle": "./node_modules/.bin/jscs .",
     "pretest": "npm run-script lint && npm run-script checkStyle",
     "test": "./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha test",
-    "posttest": "./node_modules/.bin/istanbul check-coverage && rm -rf coverage",
+    "posttest": "./node_modules/.bin/istanbul check-coverage --statements 85 --branches 65 --functions 85 --lines 85 && rm -rf coverage",
     "prepublish": "npm test && npm prune"
   },
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "istanbul": "^0.2.7",
     "jscs": "^1.4.5",
     "jshint": "^2.5.0",
+    "mc-logger": "0.0.0",
     "mocha": "^1.18.2",
     "supertest": "^0.13.0"
   },

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -2,6 +2,7 @@ var assert = require('assert')
   , request = require('supertest')
   , express = require('express')
   , createServerCluster = require('../')
+  , logger = require('mc-logger')
   , options =
     { url: 'http://localhost:5679'
     , port: 5679
@@ -30,7 +31,7 @@ describe('express-server-cluster', function () {
       server.close()
       done()
     })
-    createServerCluster(server, console, options)
+    createServerCluster(server, logger, options)
   })
 
   it('should start up a clustered server with default options', function (done) {
@@ -40,7 +41,7 @@ describe('express-server-cluster', function () {
       server.close()
       done()
     })
-    createServerCluster(server, console)
+    createServerCluster(server, logger)
   })
 
   it('should handle successful requests', function (done) {
@@ -59,7 +60,7 @@ describe('express-server-cluster', function () {
       })
 
     })
-    createServerCluster(server, console, options)
+    createServerCluster(server, logger, options)
   })
 
   it('should handle failed requests', function (done) {
@@ -86,7 +87,7 @@ describe('express-server-cluster', function () {
       })
 
     })
-    createServerCluster(server, console, options)
+    createServerCluster(server, logger, options)
   })
 
 })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -46,7 +46,7 @@ describe('express-server-cluster', function () {
   it('should handle successful requests', function (done) {
     var server = express()
     server.get('/', function (req, res) {
-      res.send(200)
+      res.sendStatus(200)
     })
     server.on('started', function (server) {
       request(server)


### PR DESCRIPTION
Now looks like this when this error occurs:

```
[2015-05-07T07:59:08.153Z] ERROR: site/37740 on Dominics-MacBook-Air.local: Error EADDRINUSE. Port 8711 already in use.

/Users/domh/Documents/node/express-server-cluster/index.js:52
      throw err
            ^
Error: listen EADDRINUSE
    at errnoException (net.js:904:11)
    at Server._listen2 (net.js:1042:14)
    at listen (net.js:1064:10)
    at Server.listen (net.js:1138:5)
    at /Users/domh/Documents/node/express-server-cluster/index.js:43:10
    at b (domain.js:183:18)
    at Domain.run (domain.js:123:23)
    at clusterMaster.logger (/Users/domh/Documents/node/express-server-cluster/index.js:27:18)
    at module.exports (/Users/domh/Documents/node/express-server-cluster/node_modules/clustered/clustered.js:28:5)
    at createServerCluster (/Users/domh/Documents/node/express-server-cluster/index.js:24:3)
```

Which enables you to easily kill the process hanging onto that port.

Also tidied up a couple of other things.
