### PR TITLE
clustered pre v1 did not have a `option.size` 

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Create a clustered express server",
   "version": "2.0.0",
   "dependencies": {
-    "clustered": "^0.2.1",
+    "clustered": "^1.0.0",
     "lodash.assign": "^4.0.6"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "express-server-cluster",
   "description": "Create a clustered express server",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "dependencies": {
     "clustered": "^1.0.0",
     "lodash.assign": "^4.0.6"


### PR DESCRIPTION
clustered added a `options.length` so you could manually override the number of processes to start. However this module passed through `options.size` to the manual override can't of every worked. 

This bumps the version of `clustered` but I think a patch release is acceptable. 
